### PR TITLE
feat: Add Emprendimiento section for DATAVIZ

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
 									<!--<li><a class="smoth-scroll" href="#services">Services</a></li>
 									<li><a class="smoth-scroll" href="#testimonial">Testimonial</a></li> -->
 									<li><a class="smoth-scroll" href="#blog">Blog</a></li>
+									<li><a class="smoth-scroll" href="#emprendimiento">Emprendimiento</a></li>
 									<li><a class="smoth-scroll" href="#contact">Contact</a></li>
 								</ul>
 							</div>
@@ -453,6 +454,37 @@
 		</div>
 	</section>
 	 // TESTIMONIAL END -->
+	<!-- // EMPRENDIMIENTO BEGIN -->
+<section id="emprendimiento">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12 text-center">
+                <h2>Emprendimiento</h2>
+            </div>
+        </div>
+        <div class="row" style="margin-top: 30px;"> <!-- Added margin-top for spacing -->
+            <!-- DATAVIZ content -->
+            <div class="col-md-12"> <!-- Wrapper for DATAVIZ content -->
+                <div class="row">
+                    <div class="col-md-5 col-sm-6">
+                        <!-- Image Placeholder -->
+                        <div style="width: 100%; height: 300px; background-color: #f0f0f0; border: 1px dashed #ccc; display: flex; align-items: center; justify-content: center;">
+                            <p style="color: #999; text-align: center;">Espacio para imagen de DATAVIZ</p>
+                        </div>
+                    </div>
+                    <div class="col-md-7 col-sm-6">
+                        <!-- DATAVIZ Text -->
+                        <h3>DATAVIZ</h3>
+                        <p>DATAVIZ es una empresa con el propósito de ayudarte a crecer tu empresa a través del perfecto entendimiento de tus datos.</p>
+                        <!-- Optional: Add a link here if DATAVIZ has a website -->
+                        <!-- <a href="#" class="btn btn-dark">Visit DATAVIZ</a> -->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<!-- // EMPRENDIMIENTO END -->
 	<!-- // CONTACT BEGIN -->
 	<section id="contact">
 		<div class="container text-center">


### PR DESCRIPTION
Adds a new "Emprendimiento" section to the webpage. This section is introduced in the navigation bar and as a new content block before the contact form.

The "Emprendimiento" section includes:
- A main title "Emprendimiento".
- A subsection for "DATAVIZ" which features:
    - A placeholder for an image (class="img-placeholder").
    - A textual description of DATAVIZ and its purpose.

I was unable to apply custom styling for this section, so it relies on default Bootstrap and existing site styles.